### PR TITLE
fix: validate mentor issue URLs

### DIFF
--- a/src/oss_dev/cli/app.py
+++ b/src/oss_dev/cli/app.py
@@ -3,6 +3,7 @@
 Professional Typer-based CLI with consistent UX, rich output, and actionable errors.
 """
 
+import re
 from pathlib import Path
 from typing import Optional
 
@@ -28,6 +29,18 @@ def _version_callback(value: bool) -> None:
     if value:
         typer.echo(f"oss-dev v{__version__}")
         raise typer.Exit()
+
+
+def _parse_issue_number(issue_url: str) -> int:
+    pattern = r"^https?://github\.com/[^/]+/[^/]+/issues/([1-9]\d*)(?:[/?#].*)?$"
+    match = re.match(pattern, issue_url)
+    if not match:
+        raise typer.BadParameter(
+            "issue_url must be a GitHub issue URL with a positive issue number, "
+            "for example: https://github.com/owner/repo/issues/123"
+        )
+
+    return int(match.group(1))
 
 
 @app.callback(invoke_without_command=True)
@@ -112,7 +125,8 @@ def mentor(
     resume: bool = typer.Option(False, "--resume", "-r", help="Resume from last checkpoint."),
 ) -> None:
     """Get step-by-step mentoring through a contribution."""
-    typer.echo(f"Mentoring for {issue_url}...")
+    issue_number = _parse_issue_number(issue_url)
+    typer.echo(f"Mentoring for issue #{issue_number}: {issue_url}...")
 
 
 @app.command()

--- a/tests/cli/test_new_cli.py
+++ b/tests/cli/test_new_cli.py
@@ -1,0 +1,38 @@
+from typer.testing import CliRunner
+
+from oss_dev.cli.app import app
+
+
+runner = CliRunner()
+
+
+def test_mentor_accepts_github_issue_url_with_positive_issue_number():
+    result = runner.invoke(
+        app,
+        ["mentor", "https://github.com/Hell1213/Oss-Dev/issues/28"],
+    )
+
+    assert result.exit_code == 0
+    assert "Mentoring for issue #28" in result.output
+
+
+def test_mentor_rejects_issue_url_without_issue_number():
+    result = runner.invoke(
+        app,
+        ["mentor", "https://github.com/Hell1213/Oss-Dev/issues/not-a-number"],
+    )
+
+    assert result.exit_code != 0
+    assert "positive issue" in result.output
+    assert "number" in result.output
+
+
+def test_mentor_rejects_non_positive_issue_number():
+    result = runner.invoke(
+        app,
+        ["mentor", "https://github.com/Hell1213/Oss-Dev/issues/0"],
+    )
+
+    assert result.exit_code != 0
+    assert "positive issue" in result.output
+    assert "number" in result.output


### PR DESCRIPTION
## Summary
- validate the oss-dev-new mentor issue URL before starting mentoring
- require a GitHub issues URL with a positive issue number
- show a clear Typer error for missing, invalid, or non-positive issue numbers
- add Typer CLI coverage for valid and invalid mentor inputs

## Tests
- uv run pytest tests\\cli\\test_new_cli.py tests\\oss\\test_github.py
- uv run ruff check src\\oss_dev\\cli\\app.py tests\\cli\\test_new_cli.py

## Notes
- Full suite: uv run pytest currently reports 54 passed and 3 existing failures in tests\\cli\\test_oss_commands.py because the legacy Click CLI exits early with a missing Gemini API key before argument validation.

Fixes #28