### PR TITLE
docs: add Google-style docstrings to errors.py classes

### DIFF
--- a/utils/errors.py
+++ b/utils/errors.py
@@ -87,4 +87,4 @@ class ConfigError(AgentError):
             details["config_file"] = config_file
         super().__init__(message, details=details, **kwargs)
         self.config_key = config_key
-        self.config_file = config_file
+        self.config_file = config_file       

--- a/utils/errors.py
+++ b/utils/errors.py
@@ -2,18 +2,38 @@ from typing import Any
 
 
 class AgentError(Exception):
+    """Base exception class for agent-related errors.
+
+    Attributes:
+        message: Human-readable error description.
+        details: Additional error context as key-value pairs.
+        cause: Original exception that caused this error.
+    """
+
     def __init__(
         self,
         message: str,
         details: dict[str, Any] | None = None,
         cause: Exception | None = None,
     ) -> None:
+        """Initialize AgentError.
+
+        Args:
+            message: Human-readable error description.
+            details: Additional error context as key-value pairs.
+            cause: Original exception that caused this error.
+        """
         super().__init__(message)
         self.message = message
         self.details = details or {}
         self.cause = cause
 
     def __str__(self) -> str:
+        """Return string representation of the error.
+
+        Returns:
+            Formatted error string with details and cause.
+        """
         base = self.message
         if self.details:
             detail_str = ", ".join(f"{k}={v}" for k, v in self.details.items())
@@ -23,6 +43,12 @@ class AgentError(Exception):
         return base
 
     def to_dict(self) -> dict[str, Any]:
+        """Convert error to dictionary representation.
+
+        Returns:
+            Dictionary containing error type, message,
+            details and cause.
+        """
         return {
             "type": self.__class__.__name__,
             "message": self.message,
@@ -32,6 +58,13 @@ class AgentError(Exception):
 
 
 class ConfigError(AgentError):
+    """Exception raised for configuration-related errors.
+
+    Attributes:
+        config_key: The configuration key that caused the error.
+        config_file: The configuration file that caused the error.
+    """
+
     def __init__(
         self,
         message: str,
@@ -39,6 +72,14 @@ class ConfigError(AgentError):
         config_file: str | None = None,
         **kwargs: Any,
     ) -> None:
+        """Initialize ConfigError.
+
+        Args:
+            message: Human-readable error description.
+            config_key: Configuration key that caused the error.
+            config_file: Configuration file that caused the error.
+            **kwargs: Additional keyword arguments passed to AgentError.
+        """
         details = kwargs.pop("details", {}) or {}
         if config_key:
             details["config_key"] = config_key


### PR DESCRIPTION
## Summary
Added Google-style docstrings to all public classes and methods in `utils/errors.py`.

## Changes
- Added class docstring to `AgentError` with Attributes section
- Added docstrings to `__init__`, `__str__`, `to_dict` methods
- Added class docstring to `ConfigError` with Attributes section  
- Added docstring to `ConfigError.__init__` method

## Related Issue
Closes #30

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactoring
- [ ] Test changes
- [ ] CI/Chore

## Testing

- [ ] `uv run ruff check` passes
- [ ] `uv run mypy` passes
- [ ] `uv run pytest` passes
- [ ] Manual testing done

## Description
Added Google-style docstrings to AgentError and ConfigError classes in utils/errors.py which were missing documentation.
