### PR TITLE
feat: add version flag to CLI entry points

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ from agent.persistence import PersistenceManager, SessionSnapshot
 from agent.session import Session
 from config.config import ApprovalPolicy, Config
 from config.loader import load_config
+from oss_dev._version import __version__
 from ui.tui import TUI, get_console
 from oss.workflow import OSSWorkflow
 
@@ -454,6 +455,7 @@ Continue from where we left off."""
 
 
 @click.group()
+@click.version_option(__version__, "--version", "-V", prog_name="oss-dev", message="%(prog)s v%(version)s")
 @click.option(
     "--cwd",
     "-c",

--- a/tests/cli/test_new_cli.py
+++ b/tests/cli/test_new_cli.py
@@ -6,6 +6,16 @@ from oss_dev.cli.app import app
 runner = CliRunner()
 
 
+def test_typer_app_version_option():
+    result = runner.invoke(
+        app,
+        ["--version"],
+    )
+
+    assert result.exit_code == 0
+    assert result.output == "oss-dev v0.2.0\n"
+
+
 def test_mentor_accepts_github_issue_url_with_positive_issue_number():
     result = runner.invoke(
         app,

--- a/tests/cli/test_oss_commands.py
+++ b/tests/cli/test_oss_commands.py
@@ -6,6 +6,7 @@ import pytest
 from click.testing import CliRunner
 
 from cli.oss_commands import oss_dev_group
+from main import main
 
 
 @pytest.fixture
@@ -92,3 +93,11 @@ def test_oss_dev_switch_requires_target(cli_runner):
     result = cli_runner.invoke(oss_dev_group, ["switch"])
     assert result.exit_code != 0
     assert "Missing argument" in result.output or "required" in result.output.lower()
+
+
+def test_main_version_option(cli_runner):
+    """Test top-level Click CLI version output."""
+    result = cli_runner.invoke(main, ["--version"])
+
+    assert result.exit_code == 0
+    assert result.output == "oss-dev v0.2.0\n"


### PR DESCRIPTION
## Summary

Add `--version` support to both CLI entry points.

## Related Issue

Fixes #25

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactoring
- [x] Test changes
- [ ] CI/Chore

## Testing

- [ ] `uv run ruff check` passes
- [ ] `uv run mypy` passes
- [ ] `uv run pytest` passes
- [x] Manual testing done

Manual testing:
- `PYTHONPATH=src python3 -m pytest tests/cli/test_new_cli.py::test_typer_app_version_option tests/cli/test_oss_commands.py::test_main_version_option`
- `python3 -m ruff check main.py src/oss_dev/cli/app.py tests/cli/test_new_cli.py tests/cli/test_oss_commands.py`

Note: Running the broader CLI test file still shows unrelated existing environment/config failures around missing Gemini API key.

## Description

Added Click `--version` / `-V` support to the top-level `oss-dev` CLI using the shared version string from `src/oss_dev/_version.py`.

Verified the Typer `oss-dev-new` CLI already uses the same shared version string and added test coverage for it.

Both entry points now print:

`oss-dev v0.2.0`

and exit cleanly without requiring config or API keys.